### PR TITLE
Source maps active only on production

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -110,7 +110,7 @@ const config = {
      |
      */
 
-    sourcemaps: ! gutils.env.production,
+    sourcemaps: ! production,
 
     /*
      |----------------------------------------------------------------


### PR DESCRIPTION
Using NODE_ENV=production when running gulp will not affect sourcemaps generation. This PR fixes the issue